### PR TITLE
Adds a command to expand an alias to its value

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,26 @@ or
 goto --list
 ```
 
+### Expand an alias
+
+To expand an alias to its value, use:
+```bash
+goto -x <alias>
+```
+or
+```bash
+goto --expand <alias>
+```
+
+#### Example
+```bash
+goto -x last_release
+```
+or
+```bash
+goto --expand last_release
+```
+
 ### Cleanup
 
 To cleanup the aliases from directories that are no longer accessible in your filesystem, use:

--- a/goto.bash
+++ b/goto.bash
@@ -309,7 +309,10 @@ function _complete_goto()
     prev="${COMP_WORDS[1]}"
 
     if [[ $prev = "-u" ]] || [[ $prev = "--unregister" ]]; then
-      # prompt with aliases only if user tries to unregister one
+      # prompt with aliases if user tries to unregister one
+      _complete_goto_aliases "$cur"
+    elif [[ $prev = "-x" ]] || [[ $prev = "--expand" ]]; then
+      # prompt with aliases if user tries to expand one
       _complete_goto_aliases "$cur"
     fi
   elif [ "$COMP_CWORD" -eq "3" ]; then

--- a/goto.bash
+++ b/goto.bash
@@ -48,6 +48,9 @@ function goto()
     -l|--list)
       _goto_list_aliases
       ;;
+    -x|--expand) # Expand an alias
+      _goto_expand_alias "$@"
+      ;;
     -h|--help)
       _goto_usage
       ;;
@@ -75,6 +78,8 @@ OPTIONS:
     goto -u|--unregister <alias>
   -l, --list: lists aliases
     goto -l|--list
+  -x, --expand: expands an alias
+    goto -x|--expand <alias>
   -c, --cleanup: cleans up non existent directory aliases
     goto -c|--cleanup
   -h, --help: prints this help
@@ -108,7 +113,24 @@ function _goto_list_aliases()
   fi
 }
 
-# Registers and alias.
+# Expands a registered alias.
+function _goto_expand_alias()
+{
+  if [ "$#" -ne "1" ]; then
+    _goto_error "usage: goto -x|--expand <alias>"
+    return
+  fi
+
+  local resolved=$(_goto_find_alias_directory $1)
+  if [ -z "$resolved" ]; then
+    _goto_error "alias '$1' does not exist"
+    return
+  fi
+
+  echo "$resolved"
+}
+
+# Registers an alias.
 function _goto_register_alias()
 {
   if [ "$#" -ne "2" ]; then
@@ -235,7 +257,7 @@ function _complete_goto_commands()
   local IFS=$' \t\n'
 
   # shellcheck disable=SC2207
-  COMPREPLY=($(compgen -W "-r --register -u --unregister -l --list -c --cleanup -v --version" -- "$1"))
+  COMPREPLY=($(compgen -W "-r --register -u --unregister -l --list -x --expand -c --cleanup -v --version" -- "$1"))
 }
 
 # Completes the goto function with the available aliases


### PR DESCRIPTION
This pull request adds a command to expand aliases. Such a command is useful which using `goto` within a script or chained/piped/xarg command, where one would prefer to reference a directory by its alias rather than its full path.

Simple example:
```
rsync -avzh `goto -x nightly_builds` `goto -x backups`
```