### PR TITLE
convention is that a sourced script should NOT have a shebang

### DIFF
--- a/goto.sh
+++ b/goto.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+# shellcheck shell=bash
 # shellcheck disable=SC2039
 # MIT License
 #


### PR DESCRIPTION
Added shellcheck directive in place of it.