### PR TITLE
fixed home path when invoked as sudo

### DIFF
--- a/install
+++ b/install
@@ -32,6 +32,7 @@ if [ $EUID -ne 0 ]; then
 	exit
 fi
 
+HOME=$(eval echo ~${SUDO_USER})
 GOTO_FILE_LOCATION='/usr/local/share/goto.sh'
 RC=""
 if [ -f ~/.bashrc ]; then

--- a/install
+++ b/install
@@ -32,7 +32,7 @@ if [ $EUID -ne 0 ]; then
 	exit
 fi
 
-HOME=$(eval echo ~${SUDO_USER})
+HOME=$(eval echo "~${SUDO_USER}")
 GOTO_FILE_LOCATION='/usr/local/share/goto.sh'
 RC=""
 if [ -f ~/.bashrc ]; then


### PR DESCRIPTION
On debian 9, when I ran the installation script with sudo:
`sudo ./install`
It modified *bashrc* file of **root** user. Although I restarted my terminal session or ran `source ~/.bashrc`
 command *goto* didn't worked. 

So I added a line to fix it. Now it modifies the **user's bashrc** file although it's invoked with **sudo**. Now I began to use the tool and adding some shortcuts.