### PR TITLE
Add colors and improve alignment in the list display

### DIFF
--- a/goto.sh
+++ b/goto.sh
@@ -123,9 +123,11 @@ _goto_expand_directory()
 # Lists registered aliases.
 _goto_list_aliases()
 {
-  local IFS=$'\n'
+  local IFS=$' '
   if [ -f "$GOTO_DB" ]; then
-    column -t "$GOTO_DB" 2>/dev/null
+    while read -r name directory; do
+      printf '\e[1;36m%20s  \e[0m%s\n' "$name" "$directory"
+    done < "$GOTO_DB"
   else
     echo "You haven't configured any directory aliases yet."
   fi


### PR DESCRIPTION
This adds colors to the list display and makes it easier to read by aligning alias names to the right.

Tested on:
- zsh 5.5.1 on Fedora 28,
- Bash 4.4.23 on Fedora 28,
- Bash 3.2.57 on macOS 10.13.

**Preview:**

![goto_improved_display](https://user-images.githubusercontent.com/180032/44005089-a7a8eaf6-9e6d-11e8-8d41-d7b01563ca90.png)

Should there be a CLI argument for disabling colored output? I can add this if desired.

This closes #35.