### PR TITLE
Create the goto database if it doesn't already exist

### DIFF
--- a/goto.sh
+++ b/goto.sh
@@ -75,6 +75,7 @@ goto()
 _goto_resolve_db()
 {
   GOTO_DB="${GOTO_DB:-$HOME/.goto}"
+  touch -a "$GOTO_DB"
 }
 
 _goto_usage()


### PR DESCRIPTION
This makes sure the goto database file is always created when entries need to be written to it.

Tested on:
- zsh 5.5.1 on Fedora 28,
- Bash 4.4.23 on Fedora 28,
- Bash 3.2.57 on macOS 10.13.

This closes #39.