### PR TITLE
Use the XDG Base Directory Specification when possible.

### DIFF
--- a/goto.sh
+++ b/goto.sh
@@ -74,7 +74,18 @@ goto()
 
 _goto_resolve_db()
 {
-  GOTO_DB="${GOTO_DB:-$HOME/.goto}"
+  if [ "$GOTO_DB" ]; then
+    GOTO_DB="$GOTO_DB/.goto"
+  else
+    # Fallback to home if there is no XDG_DATA_HOME,
+    # or if there is a db file in home and not in XDG_DATA_HOME.
+    if [ "$XDG_DATA_HOME" ] && { [ -f "$XDG_DATA_HOME/goto" ] || [ ! -f "$HOME/.goto" ]; }; then
+      GOTO_DB="$XDG_DATA_HOME/goto"
+    else
+      GOTO_DB="$HOME/.goto"
+    fi
+  fi
+
   touch -a "$GOTO_DB"
 }
 


### PR DESCRIPTION
This pull request is to make goto conform to the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), i.e., use the XDG Data Dir for the database file instead of home when possible. I've added a fallback to home when there is a database file already present, so this should not break existing installations.