### PR TITLE
Improve compatibility with various bash configs

### DIFF
--- a/goto.sh
+++ b/goto.sh
@@ -118,7 +118,7 @@ _goto_version()
 # Helpful for ~, ., .. paths
 _goto_expand_directory()
 {
-  cd "$1" 2>/dev/null && pwd
+  builtin cd "$1" 2>/dev/null && pwd
 }
 
 # Lists registered aliases.
@@ -263,7 +263,7 @@ _goto_directory()
 
   target=$(_goto_resolve_alias "$1") || return 1
 
-  cd "$target" 2> /dev/null || \
+  builtin cd "$target" 2> /dev/null || \
     { _goto_error "Failed to goto '$target'" && return 1; }
 }
 


### PR DESCRIPTION
For people who work a lot of time on their terminal, there is a high likelihood that they have made some bash configuration changes that might break goto. For example, if the .bashrc file or .bash_profile include an improvement of the cd command, `goto -r` will not work as it takes info about registering aliases from the output of the cd command.
For example, you might have a `cd() { builtin cd "$@" && ll; }` in your .bash_profile that always lists contents when cd-ing. When trying to use goto with that configuration the -r function will alias the entire directory listing which will obviously not work.

So I changed all cd calls in goto.sh with `builtin cd` which forces to use the default output of a cd command.

Tested that on Centos and MACOS.