### PR TITLE
Set the maximum length of the shortcuts as left column width

### DIFF
--- a/goto.sh
+++ b/goto.sh
@@ -128,8 +128,15 @@ _goto_list_aliases()
 {
   local IFS=$' '
   if [ -f "$GOTO_DB" ]; then
+    local maxlength=0
     while read -r name directory; do
-      printf '\e[1;36m%20s  \e[0m%s\n' "$name" "$directory"
+      local length=${#name}
+      if [[ $length -gt $maxlength ]]; then
+        local maxlength=$length
+      fi
+    done < "$GOTO_DB"
+    while read -r name directory; do
+      printf "\e[1;36m%${maxlength}s  \e[0m%s\n" "$name" "$directory"
     done < "$GOTO_DB"
   else
     echo "You haven't configured any directory aliases yet."


### PR DESCRIPTION
With `goto -l`, the width of the left column is set to the maximum length of the shortcuts.