### PR TITLE
Add folder check and create before touch db

### DIFF
--- a/goto.sh
+++ b/goto.sh
@@ -77,6 +77,10 @@ _goto_resolve_db()
 {
   local CONFIG_DEFAULT="${XDG_CONFIG_HOME:-$HOME/.config}/goto"
   GOTO_DB="${GOTO_DB:-$CONFIG_DEFAULT}"
+  GOTO_DB_CONFIG_DIRNAME=$(dirname "$GOTO_DB")
+  if [[ ! -d "$GOTO_DB_CONFIG_DIRNAME" ]]; then
+    mkdir "$GOTO_DB_CONFIG_DIRNAME"
+  fi
   touch -a "$GOTO_DB"
 }
 


### PR DESCRIPTION
I was installing macOS Big Sur and making a fresh start with all my CLI tools via brew-install, `goto` failed due to the non-existing `~/.config` folder. Just inserted few lines :)