### PR TITLE
Replace only the first space by a colon

### DIFF
--- a/goto.sh
+++ b/goto.sh
@@ -426,7 +426,7 @@ _complete_goto_zsh()
   _goto_resolve_db
   while IFS= read -r line; do
     all_aliases+=("$line")
-  done <<< "$(sed -e 's/ /:/g' $GOTO_DB 2>/dev/null)"
+  done <<< "$(sed -e 's/ /:/' $GOTO_DB 2>/dev/null)"
 
   local state
   local -a options=(


### PR DESCRIPTION
In each line of the DB, only the first space separates the alias and the directory name, hence the other spaces belong to the directory name.
