### PR TITLE
Add option for alias listing without color and alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ goto dev
 
 ```bash
 $ goto <tab>
-bc /etc/bash_completion.d                     
+bc /etc/bash_completion.d
 dev /home/iridakos/development
 rubies /home/iridakos/.rvm/rubies
 ```
@@ -154,6 +154,11 @@ goto -l
 or
 ```bash
 goto --list
+```
+
+To get the list without color, in an unaligned format for easier processing, use:
+```bash
+goto -L
 ```
 
 ### Expand an alias

--- a/goto.sh
+++ b/goto.sh
@@ -57,6 +57,9 @@ goto()
     -l|--list)
       _goto_list_aliases
       ;;
+    -L)
+      _goto_list_aliases -p
+      ;;
     -x|--expand) # Expand an alias
       _goto_expand_alias "$@"
       ;;
@@ -103,6 +106,8 @@ OPTIONS:
     goto -o|--pop
   -l, --list: lists aliases
     goto -l|--list
+  -L: Lists aliases without color, in an unaligned format for easier processing
+    goto -L
   -x, --expand: expands an alias
     goto -x|--expand <alias>
   -c, --cleanup: cleans up non existent directory aliases
@@ -140,7 +145,11 @@ _goto_list_aliases()
       fi
     done < "$GOTO_DB"
     while read -r name directory; do
-      printf "\e[1;36m%${maxlength}s  \e[0m%s\n" "$name" "$directory"
+      if [ "$1" == "-p" ]; then   # For plain text
+        printf "%s:%s\n" "$name" "$directory"
+      else
+        printf "\e[1;36m%${maxlength}s  \e[0m%s\n" "$name" "$directory"
+      fi
     done < "$GOTO_DB"
   else
     echo "You haven't configured any directory aliases yet."


### PR DESCRIPTION
This Pull Request introduces an enhancement to the goto -L command, allowing users to list aliases without any ANSI color formatting and without alignment. This change makes the output easier to process with tools like grep, awk, and sort.

With this feature, the sort functionality can be utilized externally, without the need to implement it directly in goto.