### PR TITLE
Add directory argument to installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ goto dev
 
 ```bash
 $ goto <tab>
-bc /etc/bash_completion.d                     
+bc /etc/bash_completion.d
 dev /home/iridakos/development
 rubies /home/iridakos/.rvm/rubies
 ```
@@ -31,11 +31,11 @@ rubies /home/iridakos/.rvm/rubies
 ## Installation
 
 ### Via script
-Clone the repository and run the install script as super user or root:
+Clone the repository and run the install script. Pass an optional directory location if desired.
 ```bash
 git clone https://github.com/iridakos/goto.git
 cd goto
-sudo ./install
+./install [dir]
 ```
 
 ### Manually

--- a/install
+++ b/install
@@ -23,7 +23,7 @@
 
 function _goto_install_error()
 {
-	echo "$@" >&2
+	echo -e "$@" >&2
 }
 
 #windows check
@@ -32,18 +32,17 @@ if [[ "$OSTYPE" == "msys" ]]; then
 	ON_WINDOWS=true
 fi
 
-# sudo-check
-if [ $EUID -ne 0 ] && [ "$ON_WINDOWS" == false ]; then
-	_goto_install_error 'Please run this script in sudo mode or as root user'
-	exit
+GOTO_DIR="$1"
+if [ -z "$1" ]; then
+	HOME=$(eval echo "~${SUDO_USER}")
+	if [[ $ON_WINDOWS = true ]]; then
+		GOTO_DIR='/usr/bin'
+	else
+		GOTO_DIR='/usr/local/share'
+	fi
 fi
 
-HOME=$(eval echo "~${SUDO_USER}")
-if [[ $ON_WINDOWS = true ]]; then
-	GOTO_FILE_LOCATION='/usr/bin/goto.sh'
-else
-	GOTO_FILE_LOCATION='/usr/local/share/goto.sh'
-fi
+GOTO_FILE="$GOTO_DIR/goto.sh"
 
 RC=""
 if [ -f ~/.bashrc ]; then
@@ -52,18 +51,27 @@ elif [ -f ~/.zshrc ]; then
 	RC="$HOME/.zshrc"
 fi
 
-cp ./goto.sh "$GOTO_FILE_LOCATION"
+if ! cp ./goto.sh "$GOTO_FILE" > /dev/null 2>&1; then
+	# sudo-check
+	if [ $EUID -ne 0 ] && [ "$ON_WINDOWS" == false ]; then
+		_goto_install_error "To install goto at '$GOTO_DIR' you need to run this script in sudo mode or as root user.\
+		\nAlternatively you can pass the directory as first argument: ./install <dir>"
+		exit
+	fi
+fi
 
 if [ -n "$RC" ]; then
 	# Append source to RC startup file if not already there
-	if [ "$(grep -c "source $GOTO_FILE_LOCATION" "$RC")" == "0" ]; then
+	if [ "$(grep -c "source $GOTO_FILE" "$RC")" == "0" ]; then
 		# Append source to RC file
-		echo -e "\\n\\n# Source goto\\n[[ -s \"$GOTO_FILE_LOCATION\" ]] && source $GOTO_FILE_LOCATION\\n" >> "$RC"
+		echo -e "\\n\\n# Source goto\\n[[ -s \"$GOTO_FILE\" ]] && source $GOTO_FILE\\n" >> "$RC"
 	fi
 
 	# shellcheck source=/dev/null
-	source "$GOTO_FILE_LOCATION"
+	source "$GOTO_FILE"
 else
 	_goto_install_error "Error sourcing goto in your startup file.."
 	_goto_install_error "E.g ~/.bashrc ~/.zshrc etc.."
 fi
+
+echo "Successfully installed goto at '$GOTO_FILE'"


### PR DESCRIPTION
This adds an optional argument during installation (`./install <dir>`) so the user can choose which directory to install goto.

Also, now sudo or root is only required if the current user has no privileges  on that directory.
